### PR TITLE
Fix and Added funcionality

### DIFF
--- a/Calculadora/script.js
+++ b/Calculadora/script.js
@@ -70,19 +70,17 @@ igual.addEventListener("click", function(){
     
 });
 
-arrow.addEventListener("click",function(){
-    let number = arrow.innerText;
+arrow.addEventListener("click", function() {
     let wnd = nWindow.innerText;
-    if(!["NaN","Math Error"].includes(wnd)){
-        if(number!=="0"){
-            let comp = wnd.substr(0,wnd.length-1);
-            if(comp!=""){
-                nWindow.innerText = comp;
+    if (!["NaN", "Math Error"].includes(wnd)) {
+        let comp = wnd.substr(0, wnd.length - 1);
+        if (comp != "") {
+            nWindow.innerText = comp;
+        } else if (comp == "") {
+            nWindow.innerText = "0";
         }
     }
-    
-}});
-
+});
 btn.forEach(elem => {
 	elem.addEventListener("click", function() {
 	    let number = elem.innerText;

--- a/Calculadora/script.js
+++ b/Calculadora/script.js
@@ -81,7 +81,7 @@ arrow.addEventListener("click",function(){
         }
     }
     
-});
+}});
 
 btn.forEach(elem => {
 	elem.addEventListener("click", function() {


### PR DESCRIPTION
JS fallaba al faltar corchete en "arrow.addEventListener", donde se usa retroceso para borrar números de la calculadora.
Se ha cambiado la función que contiene para que, al borrar el último número que quede, marque 0 en vez de no hacer nada.